### PR TITLE
create instrument sub-parts

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
   ## TODO
   - needs tests
   - need a way to upload rhythm json
-  - I might want to use samples rather than synthesized voices
   - More stuff I haven't thought of yet
 
   ## Stack
@@ -20,7 +19,7 @@
   - TypeScript
   - React (Vite)
   - Biome (lint/format)
-  - Elementary Audio (`@elemaudio/core`, `@elemaudio/web-renderer`)
+  - Web Audio API
 
   ## Getting Started
  1. Install dependencies:
@@ -44,18 +43,18 @@
   ```
 
   ## Rhythm Format (tablature JSON)
-  See `public/rhythms/bembe.json` and the notes in `# DrumsElementary.md`.
+  See `public/rhythms/tumbao.json` and the notes in `# DrumsElementary.md`.
 
-  Example structure:
-  ```json
-  {
-    "name": "Bembe",
-    "time_signature": "6/8",
-    "parts": {
-      "bell": "|x.x.xx|.x.x.x|",
-      "quinto": "|ts.tTT|ts.tTT|",
-      "conga": "|ptT.s.|ptT.s.|",
-      "tumba": "|T.BBtt|T.BBtt|"
-    }
-  }
-  ```
+  The parts are defined as strings of characters that correspond to different drum hits.
+  The characters are:
+  - `.`: rest
+  - `x`: stroke (typically for bell/clave/ etc.)
+  - `P`: palm
+  - `t`: touch
+  - `T`: open tone
+  - `s`: slap
+  - `M`: muff
+  - `B`: bass
+
+  
+Rhythm parts are mapped to samples in `public/samples/map.json`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,6 @@
       "name": "clavistry",
       "version": "0.1.0",
       "dependencies": {
-        "@elemaudio/core": "*",
-        "@elemaudio/web-renderer": "*",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -309,23 +307,6 @@
       ],
       "engines": {
         "node": ">=14.21.3"
-      }
-    },
-    "node_modules/@elemaudio/core": {
-      "version": "4.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "eventemitter3": "^5.0.1",
-        "invariant": "^2.2.4",
-        "shallowequal": "^1.1.0"
-      }
-    },
-    "node_modules/@elemaudio/web-renderer": {
-      "version": "4.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "@elemaudio/core": "^4.0.1",
-        "invariant": "^2.2.4"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1165,10 +1146,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "license": "MIT"
-    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -1394,13 +1371,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/invariant": {
-      "version": "2.2.4",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/is-extglob": {
@@ -1842,10 +1812,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/shallowequal": {
-      "version": "1.1.0",
-      "license": "MIT"
     },
     "node_modules/slash": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,6 @@
     "deploy": "gh-pages -d dist"
   },
   "dependencies": {
-    "@elemaudio/core": "*",
-    "@elemaudio/web-renderer": "*",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/public/rhythms/bembe.json
+++ b/public/rhythms/bembe.json
@@ -13,8 +13,17 @@
   },
   "parts": {
     "bell": "|x.x.xx|.x.x.x|",
-    "quinto": "|ts.tTT|ts.tTT|",
-    "conga": "|ptT.s.|ptT.s.|",
-    "tumba": "|T.BBtt|T.BBtt|"
+    "quinto": {
+      "left": "|B..B..|B..B..|",
+      "right": "|.s..TT|.s..TT|"
+    },
+    "conga": {
+      "left": "|B..B..|B..B..|",
+      "right": "|..T.s.|..T.s.|"
+    },
+    "tumba": {
+      "left": "|...B..|B..B..|",
+      "right": "|T.B.B.|..B.B.|"
+    }
   }
 }

--- a/public/rhythms/columbia.json
+++ b/public/rhythms/columbia.json
@@ -4,8 +4,14 @@
   "pulses_per_measure": 6,
   "parts": {
     "cowbell open": "|x.x.xx|.x.x.x|",
-    "conga": "|ptTT.s|ptTT.s|",
-    "tumba": "|ptstTT|ptstTt|"
+    "conga": {
+      "left": "|pt.T..|pt.T..|",
+      "right": "|..T..s|..T..s|"
+    },
+    "tumba": {
+      "left": "|pt.t..|pt.t..|",
+      "right": "|..s.TT|..s.TT|"
+    }
   },
   "initial_state": {
     "tempo": 144,

--- a/public/rhythms/conga_de_comparsa.json
+++ b/public/rhythms/conga_de_comparsa.json
@@ -3,13 +3,26 @@
   "time_signature": "4/4",
   "pulses_per_measure": 8,
   "parts": {
-    "agogo bell1 high": "|....x...|....x.x.|",
-    "agogo bell1 low": "|x.x....x|.x......|",
-    "agogo bell2 high": "|x.....x.|...x....|",
-    "agogo bell2 low": "|...x....|x.....x.|",
-    "quinto": "|T..ps..t|s..BT.T.|",
-    "conga": "|ttssttTT|ttssttTT|",
-    "tumba": "|B.B.B.B.|B.BT..B."
+    "agogo bell": {
+      "high": "|....xx..|....x.x.|",
+      "low": "|x.x....x|.xx.....|"
+    },
+    "cowbell": {
+      "closed": "|x.....x.|...x....|",
+      "open": "|...x....|x.....x.|"
+    },
+    "quinto": {
+      "left": "|...p...t|...B..T.|",
+      "right": "|T...s...|s...T...|"
+    },
+    "conga": {
+      "left": "|.t.s.t.T|.t.s.t.T|",
+      "right": "|t.s.t.T.|t.s.t.T.|"
+    },
+    "tumba": {
+      "left": "|..B...B.|..B...B.|",
+      "right": "|B...B...|B..T....|"
+    }
   },
   "initial_state": {
     "tempo": 144,

--- a/public/rhythms/guaguanco.json
+++ b/public/rhythms/guaguanco.json
@@ -4,10 +4,22 @@
   "pulses_per_measure": 8,
   "parts": {
     "clave": "|x..x...x|..x.x...|",
-    "palitos": "|x.xx.x.x|x.x.xx.x|",
-    "palitos2": "|xx.xxx.x|x.x.xx.x|",
-    "conga": "|.ttB.ttt|T.tT.ttt|",
-    "tumba": "|pt.BM.T.|pt.MB.T.|"
+    "palitos": {
+      "left": "|..x..x..|x....x.x|",
+      "right": "|x..x...x|..x.x...|"
+    },
+    "palitos2": {
+      "left": "|.x.x.x.x|..x..x.x|",
+      "right": "|x...x...|x...x...|"
+    },
+    "conga": {
+      "left": "|.t.B.t.t|..t..t.t|",
+      "right": "|..t...t.|T..T..t.|"
+    },
+    "tumba": {
+      "left": "|pt..M.T.|pt..M.T.|",
+      "right": "|...B..T.|...B..T.|"
+    }
   },
   "initial_state": {
     "mixer": {
@@ -16,6 +28,7 @@
       "palitos2": { "vol": 1.0, "mute": true },
       "conga": { "vol": 1.0, "mute": false },
       "tumba": { "vol": 1.0, "mute": false }
-    }
+    },
+    "tempo": 144
   }
 }

--- a/public/rhythms/tumbao.json
+++ b/public/rhythms/tumbao.json
@@ -4,10 +4,17 @@
   "pulses_per_measure": 8,
   "parts": {
     "clave": "|x..x..x.|..x.x...|",
-    "quinto": "|ptstptTT|pts..tTT|",
-    "conga": "|........|...TT...|",
-    "cowbell open": "|x...x...|x...x...|",
-    "cowbell closed": "|..xx..xx|..x...xx|"
+    "quinto": {
+      "left": "|pt.tpt..|pt.tpt..|",
+      "right": "|..s...TT|..s...TT|"
+    },
+    "conga": {
+      "left": "|........|...TT...|"
+    },
+    "cowbell": {
+      "open": "|x...x...|x...x...|",
+      "closed": "|..xx..xx|..x...xx|"
+    }
   },
   "initial_state": {
     "tempo": 144,
@@ -15,8 +22,10 @@
       "clave": { "vol": 1.0, "mute": false },
       "quinto": { "vol": 1.0, "mute": false },
       "conga": { "vol": 1.0, "mute": false },
-      "cowbell open": { "vol": 0.25, "mute": false },
-      "cowbell closed": { "vol": 0.25, "mute": false }
+      "cowbell": {
+        "open": { "vol": 0.25, "mute": false },
+        "closed": { "vol": 0.25, "mute": false }
+      }
     }
   }
 }

--- a/public/rhythms/yesa.json
+++ b/public/rhythms/yesa.json
@@ -4,9 +4,18 @@
   "pulses_per_measure": 8,
   "parts": {
     "cowbell open": "|..xx..xx|..xx..xx|",
-    "quinto": "|ssttsstt|ssttsstt|",
-    "conga": "|B...T.BB|.TTT..Bt|",
-    "tumba": "|s.B.TtTB|s..BTtTB|"
+    "quinto": {
+      "left": "|.s.t.s.t|.s.t.s.t|",
+      "right": "|s.t.s.t.|s.t.s.t.|"
+    },
+    "conga": {
+      "left": "|.......B|.T.T...t|",
+      "right": "|B...T.B.|..T...B.|"
+    },
+    "tumba": {
+      "left": "|..B..t.B|...B.t.B|",
+      "right": "|s...T.T.|s...T.T.|"
+    }
   },
   "initial_state": {
     "tempo": 120,

--- a/public/samples/map.json
+++ b/public/samples/map.json
@@ -7,15 +7,17 @@
   "quinto:s": { "file": "/samples/quinto/quinto-slap.wav" },
   "conga:T": { "file": "/samples/conga/conga-tone.wav" },
   "conga:s": { "file": "/samples/conga/conga-slap.wav" },
-  "conga:m": { "file": "/samples/conga/conga-muff.wav" },
+  "conga:M": { "file": "/samples/conga/conga-muff.wav" },
   "tumba:B": { "file": "/samples/tumba/tumba-bass.wav" },
   "tumba:T": { "file": "/samples/tumba/tumba-tone.wav" },
-  "tumba:m": { "file": "/samples/tumba/tumba-muff.wav" },
+  "tumba:M": { "file": "/samples/tumba/tumba-muff.wav" },
   "tumba:s": { "file": "/samples/tumba/tumba-slap.wav" },
-  "agogo bell1 high:x": { "file": "/samples/bell/agogo-high.wav" },
-  "agogo bell1 low:x": { "file": "/samples/bell/agogo-low.wav" },
-  "agogo bell2 high:x": { "file": "/samples/bell/agogo-high.wav" },
-  "agogo bell2 low:x": { "file": "/samples/bell/agogo-low.wav" },
-  "cowbell open:x": { "file": "/samples/bell/cowbell-open.wav" },
-  "cowbell closed:x": { "file": "/samples/bell/cowbell-closed.wav" }
+  "agogo bell": {
+    "high:x": { "file": "/samples/bell/agogo-high.wav" },
+    "low:x": { "file": "/samples/bell/agogo-low.wav" }
+  },
+  "cowbell": {
+    "open:x": { "file": "/samples/bell/cowbell-open.wav" },
+    "closed:x": { "file": "/samples/bell/cowbell-closed.wav" }
+  }
 }

--- a/src/components/Mixer.tsx
+++ b/src/components/Mixer.tsx
@@ -1,7 +1,8 @@
 import {Fragment} from 'react'
+import {Toggle} from './Toggle'
 import type {PulseMatrix} from '../rhythm/sequence'
+import type {SourceMode} from '../utils'
 
-type SourceMode = 'auto' | 'sample' | 'synth'
 type InstrumentSettings = Record<string, {vol: number; mute: boolean; source?: SourceMode}>
 
 interface MixerProps {
@@ -57,28 +58,28 @@ export function Mixer({matrix, instrumentSettings, setInstrumentSettings}: Mixer
                 <span className="vol-value">{Math.round(s.vol * 100)}%</span>
               </div>
               <div>
-                <label
+                <div
                   className="source-label"
                   style={{display: 'inline-flex', gap: 6, alignItems: 'center'}}
                 >
-                  <span>Voice</span>
-                  <select
-                    value={s.source ?? 'auto'}
-                    onChange={e =>
+                  <span className="screenreader-only">Voice</span>
+                  <Toggle
+                    value={(s.source ?? 'sample') as SourceMode}
+                    onValue={'sample' as SourceMode}
+                    offValue={'synth' as SourceMode}
+                    onLabel="Sample"
+                    offLabel="Synth"
+                    onChange={val =>
                       setInstrumentSettings(prev => ({
                         ...prev,
                         [row.instrument]: {
                           ...s,
-                          source: (e.target.value as SourceMode) ?? 'auto',
+                          source: val as SourceMode,
                         },
                       }))
                     }
-                  >
-                    <option value="auto">Auto</option>
-                    <option value="sample">Sample</option>
-                    <option value="synth">Synth</option>
-                  </select>
-                </label>
+                  />
+                </div>
               </div>
             </Fragment>
           )

--- a/src/components/RhythmView.tsx
+++ b/src/components/RhythmView.tsx
@@ -11,6 +11,90 @@ interface RhythmViewProps {
   headerIds: string[]
 }
 export function RhythmView({rhythm, matrix, currentPulse, pulseIds, headerIds}: RhythmViewProps) {
+  const renderInstrumentLabel = (raw: string, isGroupStart: boolean): JSX.Element => {
+    const [baseRaw, subRaw] = raw.includes(':') ? raw.split(':') : [raw, '']
+    const base = (baseRaw ?? '').trim()
+    const sub = (subRaw ?? '').trim().toLowerCase()
+    const sideLabel = sub === 'left' ? 'L' : sub === 'right' ? 'R' : (subRaw ?? '').trim()
+    const leftLabel = isGroupStart ? base : ''
+    return (
+      <div className="instrument-name">
+        <span className="inst-left">{leftLabel}</span>
+        <span className="inst-side">{sideLabel}</span>
+      </div>
+    )
+  }
+
+  // Base instrument label (text before ':') for grouping
+  function getBaseLabel(i: number, rows: PulseMatrix['rows']): string {
+    return (rows[i]?.instrument ?? '').split(':')[0].trim()
+  }
+
+  // Render a single matrix row with group separator, instrument label, and cells
+  function renderMatrixRow(row: PulseMatrix['rows'][number], idx: number): JSX.Element {
+    const rows = matrix.rows
+    const isGroupStart = idx === 0 || getBaseLabel(idx, rows) !== getBaseLabel(idx - 1, rows)
+    return (
+      <Fragment key={`${row.instrument}-${idx}`}>
+        {isGroupStart && idx > 0 && (
+          <div className="instrument-sep" style={{gridColumn: '1 / -1'}} aria-hidden="true" />
+        )}
+        <div style={{display: 'contents'}}>
+          {renderInstrumentLabel(row.instrument, isGroupStart)}
+          {row.symbols.map((sym, i) => {
+            const cell = (
+              <div
+                key={`${row.instrument}-${headerIds[i]}`}
+                className={`grid-cell${i === currentPulse ? ' is-current' : ''}${sym === '.' ? ' is-rest' : ''}`}
+                title={`Pulse ${i + 1}: ${sym}`}
+              >
+                {sym}
+              </div>
+            )
+            const needsSep = (i + 1) % rhythm.pulsesPerMeasure === 0 && i + 1 < matrix.totalPulses
+            return needsSep ? (
+              <Fragment key={`${row.instrument}-wrap-${headerIds[i]}`}>
+                {cell}
+                <div
+                  key={`sep-${row.instrument}-after-${headerIds[i]}`}
+                  aria-hidden="true"
+                  className="grid-sep"
+                />
+              </Fragment>
+            ) : (
+              cell
+            )
+          })}
+        </div>
+      </Fragment>
+    )
+  }
+
+  function renderHeaderCells(): JSX.Element[] {
+    const {pulsesPerBeat, isCompound} = getMeterInfo(rhythm.timeSignature, matrix.pulsesPerMeasure)
+    const simpleSyllables = ['1', '&']
+    const compoundSyllables = ['1', '&', 'a']
+    const cells: JSX.Element[] = []
+    for (let i = 0; i < matrix.totalPulses; i++) {
+      const posInBeat = i % pulsesPerBeat
+      const syllables = isCompound ? compoundSyllables : simpleSyllables
+      const pulsesIntoMeasure = i % rhythm.pulsesPerMeasure
+      const beatInMeasure = Math.floor(pulsesIntoMeasure / pulsesPerBeat) + 1
+      const label = posInBeat === 0 ? String(beatInMeasure) : (syllables[posInBeat] ?? '')
+      cells.push(
+        <div key={headerIds[i]} className="header-label">
+          {label}
+        </div>,
+      )
+      if ((i + 1) % rhythm.pulsesPerMeasure === 0 && i + 1 < matrix.totalPulses) {
+        cells.push(
+          <div key={`sep-h-after-${headerIds[i]}`} aria-hidden="true" className="grid-sep" />,
+        )
+      }
+    }
+    return cells
+  }
+
   return (
     <div className="rhythm-card">
       <h2 style={{marginTop: 0}}>{rhythm.name}</h2>
@@ -33,67 +117,8 @@ export function RhythmView({rhythm, matrix, currentPulse, pulseIds, headerIds}: 
         return (
           <div className="rhythm-grid" style={{gridTemplateColumns}}>
             <div className="header-label">Instrument</div>
-            {(() => {
-              const {pulsesPerBeat, isCompound} = getMeterInfo(
-                rhythm.timeSignature,
-                matrix.pulsesPerMeasure,
-              )
-              const simpleSyllables = ['1', '&']
-              const compoundSyllables = ['1', '&', 'a']
-              const cells: JSX.Element[] = []
-              for (let i = 0; i < matrix.totalPulses; i++) {
-                const posInBeat = i % pulsesPerBeat
-                const syllables = isCompound ? compoundSyllables : simpleSyllables
-                const pulsesIntoMeasure = i % rhythm.pulsesPerMeasure
-                const beatInMeasure = Math.floor(pulsesIntoMeasure / pulsesPerBeat) + 1
-                const label = posInBeat === 0 ? String(beatInMeasure) : (syllables[posInBeat] ?? '')
-                cells.push(
-                  <div key={headerIds[i]} className="header-label">
-                    {label}
-                  </div>,
-                )
-                if ((i + 1) % rhythm.pulsesPerMeasure === 0 && i + 1 < matrix.totalPulses) {
-                  cells.push(
-                    <div
-                      key={`sep-h-after-${headerIds[i]}`}
-                      aria-hidden="true"
-                      className="grid-sep"
-                    />,
-                  )
-                }
-              }
-              return cells
-            })()}
-            {matrix.rows.map(row => (
-              <div key={row.instrument} style={{display: 'contents'}}>
-                <div className="instrument-name">{row.instrument}</div>
-                {row.symbols.map((sym, i) => {
-                  const cell = (
-                    <div
-                      key={`${row.instrument}-${headerIds[i]}`}
-                      className={`grid-cell${i === currentPulse ? ' is-current' : ''}${sym === '.' ? ' is-rest' : ''}`}
-                      title={`Pulse ${i + 1}: ${sym}`}
-                    >
-                      {sym}
-                    </div>
-                  )
-                  const needsSep =
-                    (i + 1) % rhythm.pulsesPerMeasure === 0 && i + 1 < matrix.totalPulses
-                  return needsSep ? (
-                    <Fragment key={`${row.instrument}-wrap-${headerIds[i]}`}>
-                      {cell}
-                      <div
-                        key={`sep-${row.instrument}-after-${headerIds[i]}`}
-                        aria-hidden="true"
-                        className="grid-sep"
-                      />
-                    </Fragment>
-                  ) : (
-                    cell
-                  )
-                })}
-              </div>
-            ))}
+            {renderHeaderCells()}
+            {matrix.rows.map(renderMatrixRow)}
           </div>
         )
       })()}

--- a/src/components/Toggle.tsx
+++ b/src/components/Toggle.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+
+export interface ToggleProps<T extends string | number | boolean = boolean> {
+  value: T
+  onValue: T
+  offValue: T
+  onLabel: string
+  offLabel: string
+  onChange: (value: T) => void
+  disabled?: boolean
+  id?: string
+}
+
+export function Toggle<T extends string | number | boolean = boolean>({
+  value,
+  onValue,
+  offValue,
+  onLabel,
+  offLabel,
+  onChange,
+  disabled,
+}: ToggleProps<T>) {
+  const checked = value === onValue
+  return (
+    <div className="toggle">
+      <span className="toggle-label toggle-label-off">{offLabel}</span>
+      <button
+        type="button"
+        className={`toggle-switch${checked ? ' is-on' : ''}`}
+        role="switch"
+        aria-checked={checked}
+        aria-label={checked ? onLabel : offLabel}
+        onClick={() => onChange(checked ? offValue : onValue)}
+        disabled={disabled}
+      >
+        <span className="toggle-track">
+          <span className="toggle-thumb" />
+        </span>
+      </button>
+      <span className="toggle-label toggle-label-on">{onLabel}</span>
+    </div>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -21,6 +21,65 @@ button:disabled {
   cursor: not-allowed;
 }
 
+.screenreader-only {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+  transform: translatez(0);
+}
+
+/* Toggle */
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.toggle-label {
+  font-size: 12px;
+  opacity: 0.8;
+}
+.toggle-switch {
+  position: relative;
+  width: 42px;
+  height: 24px;
+  border: 1px solid #2b355f;
+  background: #1a2140;
+  border-radius: 999px;
+  padding: 0;
+  cursor: pointer;
+}
+.toggle-switch.is-on {
+  background: #2a3a70;
+  border-color: #3c53a5;
+}
+.toggle-track {
+  position: absolute;
+  inset: 0;
+  border-radius: 999px;
+}
+.toggle-thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 20px;
+  height: 20px;
+  background: #e9eef5;
+  border-radius: 50%;
+  transition: left 0.15s ease;
+}
+.toggle-switch.is-on .toggle-thumb {
+  left: 20px;
+}
+.toggle-switch:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .icon {
   color: #f5f5f5;
 }
@@ -65,7 +124,8 @@ button:disabled {
 
   .rhythm-grid {
     display: grid;
-    gap: 6px;
+    column-gap: 6px;
+    row-gap: 12px;
     align-items: center;
   }
 
@@ -76,6 +136,21 @@ button:disabled {
 
   .instrument-name {
     font-weight: 600;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    margin-inline-end: .5rem;
+  }
+
+  .inst-left {
+    text-align: left;
+  }
+
+  .inst-side {
+    text-align: right;
+    opacity: 0.8;
+    min-width: 1.25rem;
   }
 
   .grid-cell {

--- a/src/rhythm/sequence.ts
+++ b/src/rhythm/sequence.ts
@@ -3,6 +3,40 @@ import type {ParsedRhythm, StrokeSymbol} from './types'
 export interface PulseRow {
   instrument: string
   symbols: StrokeSymbol[] // length = totalPulses
+  // For sample selection only: when a part has labeled subparts, this carries
+  // the instrument name augmented with the sub-label (e.g., "cowbell open").
+  // Mixer routing should continue to use `instrument`.
+  sampleInstrument?: string
+}
+
+// Build a matrix for PLAYBACK, expanding any left/right subparts into distinct rows
+// so simultaneous strikes are preserved. Both rows keep the same instrument name
+// so they route through the same mixer channel.
+export function buildPlaybackMatrix(r: ParsedRhythm): PulseMatrix {
+  const N = r.pulsesPerMeasure
+  const maxLen = r.parts.reduce((m, p) => Math.max(m, p.tokens.length), 0)
+
+  const padTo = (arr: StrokeSymbol[], len: number): StrokeSymbol[] => {
+    if (arr.length >= len) return arr.slice(0, len)
+    return arr.concat(Array.from({length: len - arr.length}, () => '.') as StrokeSymbol[])
+  }
+
+  const rows: PulseRow[] = []
+  for (const p of r.parts) {
+    if (p.displaySubparts && p.displaySubparts.length > 0) {
+      for (const sp of p.displaySubparts) {
+        rows.push({
+          instrument: p.instrument,
+          sampleInstrument: `${p.instrument} ${sp.label}`,
+          symbols: padTo(sp.tokens as StrokeSymbol[], maxLen),
+        })
+      }
+    } else {
+      rows.push({instrument: p.instrument, sampleInstrument: p.instrument, symbols: padTo(p.tokens as StrokeSymbol[], maxLen)})
+    }
+  }
+
+  return {pulsesPerMeasure: N, totalPulses: maxLen, rows}
 }
 
 export interface PulseMatrix {
@@ -26,6 +60,34 @@ export function buildPulseMatrix(r: ParsedRhythm): PulseMatrix {
     }
     return {instrument: p.instrument, symbols: line}
   })
+
+  return {pulsesPerMeasure: N, totalPulses: maxLen, rows}
+}
+
+// Build a matrix for DISPLAY only, expanding any left/right subparts into distinct rows.
+export function buildDisplayMatrix(r: ParsedRhythm): PulseMatrix {
+  const N = r.pulsesPerMeasure
+  // Determine total length across all merged tokens (same as playback)
+  const maxLen = r.parts.reduce((m, p) => Math.max(m, p.tokens.length), 0)
+
+  const padTo = (arr: StrokeSymbol[], len: number): StrokeSymbol[] => {
+    if (arr.length >= len) return arr.slice(0, len)
+    return arr.concat(Array.from({length: len - arr.length}, () => '.') as StrokeSymbol[])
+  }
+
+  const rows: PulseRow[] = []
+  for (const p of r.parts) {
+    if (p.displaySubparts && p.displaySubparts.length > 0) {
+      for (const sp of p.displaySubparts) {
+        rows.push({
+          instrument: `${p.instrument}: ${sp.label}`,
+          symbols: padTo(sp.tokens as StrokeSymbol[], maxLen),
+        })
+      }
+    } else {
+      rows.push({instrument: p.instrument, symbols: padTo(p.tokens as StrokeSymbol[], maxLen)})
+    }
+  }
 
   return {pulsesPerMeasure: N, totalPulses: maxLen, rows}
 }

--- a/src/rhythm/types.ts
+++ b/src/rhythm/types.ts
@@ -14,10 +14,12 @@ type MixerInstrumentState = {
   mute?: boolean
 }
 
+export type PartValue = string | Record<string, string>
+
 export interface RhythmJSON {
   name: string
   time_signature: string // e.g. "6/8"
-  parts: Record<string, string> // instrument -> tablature line
+  parts: Record<string, PartValue> // instrument -> tablature line(s)
   pulses_per_measure?: number // optional explicit grid resolution per measure
   initial_state?: {
     mixer?: Record<string, MixerInstrumentState>
@@ -27,8 +29,9 @@ export interface RhythmJSON {
 
 export interface ParsedPart {
   instrument: string
-  raw: string // original tablature string
-  tokens: StrokeSymbol[] // includes only strokes and rests (no '|')
+  raw: string // original tablature (single line or merged for L/R)
+  tokens: StrokeSymbol[] // merged playable line (no '|')
+  displaySubparts?: {label: string; tokens: StrokeSymbol[]}[] // optional UI-only split lines
 }
 
 export interface ParsedRhythm {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,7 +14,7 @@ export function toBaseName(name: string): string {
 
 // Initial state utilities
 
-export type SourceMode = 'auto' | 'sample' | 'synth'
+export type SourceMode = 'sample' | 'synth'
 export type InstrumentSetting = {vol: number; mute: boolean; source?: SourceMode}
 export type InstrumentSettingInput = {vol?: number; mute?: boolean; source?: SourceMode}
 
@@ -26,20 +26,19 @@ export function deriveInitialState(json: RhythmJSON): {
   // Start with defaults for all instruments present in the parts
   const mixer: Record<string, InstrumentSetting> = {}
   for (const inst of Object.keys(json.parts ?? {})) {
-    mixer[inst] = {vol: 1.0, mute: false, source: 'auto'}
+    mixer[inst] = {vol: 1.0, mute: false, source: 'sample'}
   }
   // Overlay any user-provided mixer entries from initial_state
   const mixerInput = json.initial_state?.mixer ?? {}
   for (const [inst, rawVal] of Object.entries(mixerInput as Record<string, unknown>)) {
     let vol = 1.0
     let mute = false
-    let source: SourceMode | undefined = 'auto'
+    let source: SourceMode | undefined = 'sample'
     if (rawVal && typeof rawVal === 'object') {
       const obj = rawVal as InstrumentSettingInput
       if (typeof obj.vol === 'number') vol = obj.vol
       if (typeof obj.mute === 'boolean') mute = obj.mute
-      if (obj.source === 'auto' || obj.source === 'sample' || obj.source === 'synth')
-        source = obj.source
+      if (obj.source === 'sample' || obj.source === 'synth') source = obj.source
     }
     mixer[inst] = {vol, mute, source}
   }

--- a/tsconfig.tsbuildinfo
+++ b/tsconfig.tsbuildinfo
@@ -1,1 +1,1 @@
-{"root":["./src/app.tsx","./src/main.tsx","./src/utils.ts","./src/audio/samples.ts","./src/audio/voices.ts","./src/components/mixer.tsx","./src/components/rhythmview.tsx","./src/rhythm/parser.ts","./src/rhythm/sequence.ts","./src/rhythm/types.ts"],"version":"5.9.2"}
+{"root":["./src/app.tsx","./src/main.tsx","./src/utils.ts","./src/audio/samples.ts","./src/audio/voices.ts","./src/components/mixer.tsx","./src/components/rhythmview.tsx","./src/components/toggle.tsx","./src/rhythm/parser.ts","./src/rhythm/sequence.ts","./src/rhythm/types.ts"],"version":"5.9.2"}


### PR DESCRIPTION
- this enables separating the right and left hands in the parts and different sounds like an open/closed cowbell
- change the select to a toggle for synth v sample
- removed Elementary since it wasn't being used. the app relies solely a web audio